### PR TITLE
Generate NC or LP file based on provided path

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1077,9 +1077,13 @@ class Model:
             )
 
         if only_generate_problem_file:
-            nc_fn = problem_fn.with_suffix(".nc")
-            self.to_netcdf(nc_fn)
-            logger.info(f"Solver problem file written as NetCDF to `{nc_fn}`.")
+            if isinstance(only_generate_problem_file, str):
+                problem_fn = Path(only_generate_problem_file)
+                self.to_file(problem_fn)
+            else:
+                nc_fn = problem_fn.with_suffix(".nc")
+                self.to_netcdf(nc_fn)
+            logger.info(f"Solver problem file written to `{problem_fn}`.")
             logger.info("Exiting here because only_generate_problem_file is True.")
             sys.exit(0)
 


### PR DESCRIPTION
### Summary

This PR updates the logic in the solve_network function to handle the only_generate_problem_file option, which can now accept both boolean and string values.

If it's a string, it will use the provided path for the problem file (e.g., /tmp/pypsa-eur-elec-10-lvopt-3h.lp).
If it's a boolean, it will generate a default path.

Changes:
Updated the logic to support both string and boolean types for only_generate_problem_file.